### PR TITLE
Update for Elixir 1.17 and OTP 27.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.17.3-otp-27
+erlang 27.2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # A writer for Elixlsx library that support writing large excel file
+## Installation
 
+As of version 0.2, elixlsx_writer requires Elixir 1.12 or above.
+
+Installation via Hex, in `mix.exs`:
+
+```elixir
+defp deps do
+  [{:elixlsx_writer, "~> 0.2.0"}]
+end
+```
+
+Via GitHub:
+
+```elixir
+defp deps do
+  [{:elixlsx_writer, github: "bluzky/elixlsx-writer"}]
+end
+```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # A writer for Elixlsx library that support writing large excel file
 ## Installation
 
-As of version 0.2, elixlsx_writer requires Elixir 1.12 or above.
+elixlsx_writer v0.3.0 and above requires Elixir 1.17+.
 
 Installation via Hex, in `mix.exs`:
 
 ```elixir
 defp deps do
-  [{:elixlsx_writer, "~> 0.2.0"}]
+  [{:elixlsx_writer, "~> 0.3.0"}]
 end
 ```
 

--- a/lib/elixlsx_writer.ex
+++ b/lib/elixlsx_writer.ex
@@ -59,7 +59,7 @@ defmodule ElixlsxWriter do
       |> Enum.concat(sheet_files)
       |> Enum.map(fn path -> path |> Path.relative_to(writer.temp_dir) |> String.to_charlist() end)
 
-    rs = :zip.create(to_charlist(writer.output_file), files, cwd: to_char_list(writer.temp_dir))
+    rs = :zip.create(to_charlist(writer.output_file), files, cwd: to_charlist(writer.temp_dir))
 
     cleanup(writer)
     rs

--- a/lib/elixlsx_writer.ex
+++ b/lib/elixlsx_writer.ex
@@ -59,7 +59,7 @@ defmodule ElixlsxWriter do
       |> Enum.concat(sheet_files)
       |> Enum.map(fn path -> path |> Path.relative_to(writer.temp_dir) |> String.to_charlist() end)
 
-    rs = :zip.create(to_charlist(writer.output_file), files, cwd: writer.temp_dir)
+    rs = :zip.create(to_charlist(writer.output_file), files, cwd: to_char_list(writer.temp_dir))
 
     cleanup(writer)
     rs

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Elixlsx2.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/bluzky/elixlsx-writer"
-  @version "0.1.0"
+  @version "0.2.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Elixlsx2.Mixfile do
     [
       app: :elixlsx_writer,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.17",
       package: package(),
       description:
         "Elixlsx-writer is a writer for Elixlsx library, supporting writing large data to xlsx file by chunks. So you don't have to load all data into memory before writing to file.",
@@ -25,7 +25,7 @@ defmodule Elixlsx2.Mixfile do
 
   defp deps do
     [
-      {:elixlsx, "~> 0.6.0"},
+      {:elixlsx, git: "https://github.com/ARPC/elixlsx.git", branch: "main"},
       {:credo, "~> 1.7", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:dialyxir, "~> 1.3", only: [:dev], runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Elixlsx2.Mixfile do
 
   defp deps do
     [
-      {:elixlsx, "~> 0.5.1"},
+      {:elixlsx, "~> 0.6.0"},
       {:credo, "~> 1.7", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:dialyxir, "~> 1.3", only: [:dev], runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Elixlsx2.Mixfile do
   use Mix.Project
 
   @source_url "https://github.com/bluzky/elixlsx-writer"
-  @version "0.2.0"
+  @version "0.3.0"
 
   def project do
     [
@@ -25,7 +25,7 @@ defmodule Elixlsx2.Mixfile do
 
   defp deps do
     [
-      {:elixlsx, git: "https://github.com/ARPC/elixlsx.git", branch: "main"},
+      {:elixlsx, "~> 0.6"},
       {:credo, "~> 1.7", only: [:dev, :test]},
       {:ex_doc, ">= 0.0.0", only: [:dev], runtime: false},
       {:dialyxir, "~> 1.3", only: [:dev], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "dialyxir": {:hex, :dialyxir, "1.3.0", "fd1672f0922b7648ff9ce7b1b26fcf0ef56dda964a459892ad15f6b4410b5284", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "00b2a4bcd6aa8db9dcb0b38c1225b7277dca9bc370b6438715667071a304696f"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm", "000aaeff08919e95e7aea13e4af7b2b9734577b3e6a7c50ee31ee88cab6ec4fb"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
-  "elixlsx": {:hex, :elixlsx, "0.5.1", "3b4129c7059c7bd2ed4e2ff5f6c485410ab125058bee2e9de6e0eb8417176803", [:mix], [], "hexpm", "25d778d43ea1ae86df8dd20170842d324086c0cab40503eb484a3779a6e2254c"},
+  "elixlsx": {:git, "https://github.com/ARPC/elixlsx.git", "d24fa3843c82cf2a584637544623eb8c0aeea599", [branch: "main"]},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
   "excheck": {:hex, :excheck, "0.5.3", "7326a29cc5fdb6900e66dac205a6a70cc994e2fe037d39136817d7dab13cdabf", [:mix], [], "hexpm", "2a27ffeff9d3b2ef45c454efb13990f08bc2578f93fd6d054025da74775ca869"},

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "dialyxir": {:hex, :dialyxir, "1.3.0", "fd1672f0922b7648ff9ce7b1b26fcf0ef56dda964a459892ad15f6b4410b5284", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "00b2a4bcd6aa8db9dcb0b38c1225b7277dca9bc370b6438715667071a304696f"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm", "000aaeff08919e95e7aea13e4af7b2b9734577b3e6a7c50ee31ee88cab6ec4fb"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.12", "b245e875ec0a311a342320da0551da407d9d2b65d98f7a9597ae078615af3449", [:mix], [], "hexpm", "711e2cc4d64abb7d566d43f54b78f7dc129308a63bc103fbd88550d2174b3160"},
-  "elixlsx": {:git, "https://github.com/ARPC/elixlsx.git", "d24fa3843c82cf2a584637544623eb8c0aeea599", [branch: "main"]},
+  "elixlsx": {:hex, :elixlsx, "0.6.0", "858c2c821ab52f4ca0988adce188d19f3b239a4fff8b36b26cd81ec8af9b2ab3", [:mix], [], "hexpm", "c4766f47afea075a85950a5c6fe981e98b8b8a30cc076382aaacf2bb8dbcd25d"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
   "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
   "excheck": {:hex, :excheck, "0.5.3", "7326a29cc5fdb6900e66dac205a6a70cc994e2fe037d39136817d7dab13cdabf", [:mix], [], "hexpm", "2a27ffeff9d3b2ef45c454efb13990f08bc2578f93fd6d054025da74775ca869"},


### PR DESCRIPTION
## Summary by Sourcery

Update project to Elixir 1.17 and OTP 27.2, and bump the version to 0.3.0. Update the installation instructions in the README to reflect the new version requirement.